### PR TITLE
Adding test of launch measurements in amd_vtpm.py

### DIFF
--- a/keylime/registrar_client.py
+++ b/keylime/registrar_client.py
@@ -4,6 +4,7 @@ import sys
 from keylime import api_version as keylime_api_version
 from keylime import crypto, json, keylime_logging
 from keylime.requests_client import RequestsClient
+from keylime.tpm import amd_vtpm
 
 logger = keylime_logging.init_logging("registrar_client")
 api_version = keylime_api_version.current_version()
@@ -93,7 +94,7 @@ def doRegisterAgent(
         "ekcert": ekcert,
         "aik_tpm": aik_tpm,
     }
-    if ekcert is None or ekcert == "emulator":
+    if ekcert is None or ekcert == "emulator" or amd_vtpm.is_amd_vtpm(base64.b64decode(ekcert)):
         data["ek_tpm"] = ek_tpm
 
     if mtls_cert is not None:

--- a/keylime/tenant.py
+++ b/keylime/tenant.py
@@ -432,7 +432,7 @@ class Tenant:
                 logger.warning("No EK cert provided, require_ek_cert option in config set to True")
                 return False
             elif amd_vtpm.is_amd_vtpm(base64.b64decode(ekcert)):
-                if not amd_vtpm.verify_ekcert_surrogate(base64.b64decode(ekcert)):
+                if not amd_vtpm.verify_ekcert_surrogate(base64.b64decode(ekcert), self.mb_refstate):
                     logger.warning("Invalid attestation report in amd vTPM")
                     return False
                 return True

--- a/keylime/tpm/amd_vtpm.py
+++ b/keylime/tpm/amd_vtpm.py
@@ -81,12 +81,3 @@ def verify_ekcert_surrogate(EKcert_surrogate, mb_refstate: dict):
 
     logger.info("Successfully verified amd vTPM attestation report")
     return True
-
-
-# check actual SEV launch measurement against the measured boot refstate
-def verify_launch_measurement(EKcert_surrogate, mb_refstate: dict):
-
-    # unpack actual launch measurement from attestation report
-    alm=struct.unpack('<48s', EKcert_surrogate[0x90:0xC0])[0]
-    alms = "0x" + alm.hex()
-

--- a/keylime/tpm/amd_vtpm.py
+++ b/keylime/tpm/amd_vtpm.py
@@ -43,19 +43,23 @@ def is_amd_vtpm(EKcert_surrogate):
     vmpl=struct.unpack('<I', EKcert_surrogate[0x30:0x34])[0]
     return (vmpl == 0) and (version == 2) and (len(EKcert_surrogate) == 1184)
 
-def verify_ekcert_surrogate(EKcert_surrogate):
+def verify_ekcert_surrogate(EKcert_surrogate, mb_refstate: dict):
     vmpl=struct.unpack('<I', EKcert_surrogate[0x30:0x34])[0]
     if (vmpl > 0):
         logger.error("Using an attestation report from VMPL %d"%vmpl)
         return False
 
-    # TODO: to ask: where do we store/get allowed measures? Is the format ok?
-    #measurement=struct.unpack('<48s', EKcert_surrogate[0x90:0xC0])[0].hex()
-    #fp = open('allowed_measures.json', 'rb')
-    #jdata = json.load(fp)
-    #if not(measurement_allowed(measurement, jdata)):
-    #    return False
-
+    # load SEV launch measurement, compare with measured boot refstate (if there is one)
+    alm="0x" + struct.unpack('<48s', EKcert_surrogate[0x90:0xC0])[0].hex()
+    logger.info("actual launch measurement=%s"%(alm))
+    if not (mb_refstate and 'launch_measurements' in mb_refstate):
+        logger.info("SEV launch measurement ignored because mb_refstate does not have launch measurements")
+    elif alm in mb_refstate['launch_measurements']:
+        logger.info("SEV launch measurement found in measured boot refstate")
+    else:
+        logger.error("SEV launch measurement does not match any provided in the measured boot refstate")
+        return False
+    
     sigRS=struct.unpack('<72s72s368x', EKcert_surrogate[0x2A0:0x4A0])
     R=int.from_bytes(sigRS[0], 'little')
     S=int.from_bytes(sigRS[1], 'little')
@@ -77,3 +81,12 @@ def verify_ekcert_surrogate(EKcert_surrogate):
 
     logger.info("Successfully verified amd vTPM attestation report")
     return True
+
+
+# check actual SEV launch measurement against the measured boot refstate
+def verify_launch_measurement(EKcert_surrogate, mb_refstate: dict):
+
+    # unpack actual launch measurement from attestation report
+    alm=struct.unpack('<48s', EKcert_surrogate[0x90:0xC0])[0]
+    alms = "0x" + alm.hex()
+

--- a/keylime/tpm/amd_vtpm.py
+++ b/keylime/tpm/amd_vtpm.py
@@ -1,0 +1,79 @@
+from keylime import keylime_logging
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import utils, ec
+import requests
+import struct
+import json
+
+logger = keylime_logging.init_logging('vtpm')
+
+def measurement_allowed(measurement, allowed_list_json):
+    for i in allowed_list_json:
+        if i['measure'] == measurement:
+            return True
+
+    return False
+
+def get_vcek(EKcert_surrogate):
+    tcb=struct.unpack('<BB4xBB', EKcert_surrogate[0x180:0x188])
+    chipID=struct.unpack('<64s', EKcert_surrogate[0x1a0:0x1E0])[0].hex()
+    url = ("https://kdsintf.amd.com/vcek/v1/Milan/" + chipID +
+           "?blSPL=%02d"%tcb[0] + "&teeSPL=%02d"%tcb[1] +
+           "&snpSPL=%02d"%tcb[2] + "&ucodeSPL=%02d"%tcb[3])
+
+    response = requests.get(url)
+
+    if (response.status_code < 200 or response.status_code > 299):
+        logger.error("Could not download vcek")
+        return None
+
+    return response.content
+
+def is_amd_vtpm_ek_valid(EKpub, EKcert_surrogate):
+    ekpub_sha512=struct.unpack('<64s', EKcert_surrogate[0x50:0x90])[0]
+    hasher = hashes.Hash(hashes.SHA512())
+    hasher.update(EKpub)
+    digest = hasher.finalize()
+    return (digest == ekpub_sha512)
+
+# TODO: is this good enough?
+def is_amd_vtpm(EKcert_surrogate):
+    version = struct.unpack('<I', EKcert_surrogate[0x0:0x4])[0]
+    vmpl=struct.unpack('<I', EKcert_surrogate[0x30:0x34])[0]
+    return (vmpl == 0) and (version == 2) and (len(EKcert_surrogate) == 1184)
+
+def verify_ekcert_surrogate(EKcert_surrogate):
+    vmpl=struct.unpack('<I', EKcert_surrogate[0x30:0x34])[0]
+    if (vmpl > 0):
+        logger.error("Using an attestation report from VMPL %d"%vmpl)
+        return False
+
+    # TODO: to ask: where do we store/get allowed measures? Is the format ok?
+    #measurement=struct.unpack('<48s', EKcert_surrogate[0x90:0xC0])[0].hex()
+    #fp = open('allowed_measures.json', 'rb')
+    #jdata = json.load(fp)
+    #if not(measurement_allowed(measurement, jdata)):
+    #    return False
+
+    sigRS=struct.unpack('<72s72s368x', EKcert_surrogate[0x2A0:0x4A0])
+    R=int.from_bytes(sigRS[0], 'little')
+    S=int.from_bytes(sigRS[1], 'little')
+    signature = utils.encode_dss_signature(R,S)
+
+    hasher = hashes.Hash(hashes.SHA384())
+    hasher.update(EKcert_surrogate[0:0x2A0])
+    digest = hasher.finalize()
+
+    vcek = get_vcek(EKcert_surrogate)
+    cert = x509.load_der_x509_certificate(vcek)
+    public_key = cert.public_key()
+
+    try:
+        public_key.verify(signature, digest, ec.ECDSA(utils.Prehashed(hashes.SHA384())))
+    except Exception as e:
+        logger.error("Failed to verify signature, %s"%(str(e)))
+        return False
+
+    logger.info("Successfully verified amd vTPM attestation report")
+    return True


### PR DESCRIPTION
From the code this PR is replacing:
# TODO: to ask: where do we store/get allowed measures? Is the format ok?

* The allowed measures are from the measured boot refstate, which is a JSON file, and is represented as a dictionary within keylime.
* It seems to make sense to attach launch measurement checks to measured boot refstates in keylime, since the launch measurement largely overlaps the measured boot information (launch measurement: an amalgamated hash of the guest kernel, guest firmware, guest SVSM ...; measured boot policy: guest firmware, guest kernel, guest grub, guest shim, guest initramfs ...)
* Moreover, since the attestation report (and the launch measurements) are verified during the keylime initial quote, and the measured boot policy is available at this time (having been provided with the keylime tenant `add` command)
* The current measured boot policy has a flexible format, but I propose we use this:
```
{
   "hostosboot": [ ... list of allowed kernels and initramfs measurements ... ]   <---- current
   "firmware": [ ... list of firmware measurements ...]  <---- current
   "launch_measurements": [ ... list of measurements allowed ... ] <------- PROPOSED
}
```

E.g. this is the current value while testing on sl-milan01:
```
{
  "hostosboots": [
    {
      "tag": "hibinst",
      "shim_authcode_sha256": "0xdbffd70a2c43fd2c1931f18b8f8c08c5181db15f996f747dfed34def52fad036",
      "grub_authcode_sha256": "0xacc00aad4b0413a8b349b4493f95830da6a7a44bd6fc1579f6f53c339c26cb05",
      "kernel_authcode_sha256": "0x424771d6a01447e855a9b1666e5e28279ff49746c1b41614366ce84aeb05abd0",
      "kernel_plain_sha256": "0xd51bdbeb18b0f82a59e6b8fb9eace3e261bd137b2eb23135ec8f55b27f188e00",
      "initrd_plain_sha256": "0x059cc37868d832147d9e5083cad4bf5d060da248478cc2bf6d29e2cf464d6fed"
    }
  ],
  "launch_measurements": [
      "0x12d75089a57e6092c34f1efc8043ee878523836c97c004791de6ca63248671a8737364ebb404014a9b23f3b77275ed7b"
  ]
}
```